### PR TITLE
Updated commit to point to latest ADSP-SC589-MINI.

### DIFF
--- a/REL-YOCTO-2.0.0-BETA-1.xml
+++ b/REL-YOCTO-2.0.0-BETA-1.xml
@@ -9,7 +9,7 @@
 
   <project remote="yocto" revision="6ebb33bdaccaeadff0c85aab27acf35723df00d8" name="poky" path="sources/poky"/> <!-- dunfell revision -->
   <project remote="oe" revision="11eae114522a6befa06c7f4021a83bc016133543" name="meta-openembedded" path="sources/meta-openembedded"/> <!-- dunfell revision -->
-  <project remote="adigithub" revision="da9268ea7a19bb4a740c3392d42fb059840d9412" name="lnxdsp-adi-meta" path="sources/meta-adi"/>
+  <project remote="adigithub" revision="7428b36b9133be9d4351a8d55408e4e54af39ef9" name="lnxdsp-adi-meta" path="sources/meta-adi"/>
   <project remote="adigithub" revision="130d7a846aae7539eafb2ea22c44f2d0237dc39e" name="lnxdsp-scripts" path="sources">
 	  <linkfile dest="setup-environment" src="setup-environment"/>
   </project>>


### PR DESCRIPTION
Updated manifest commit to point to update for ADSP-SC589-MINI https://github.com/analogdevicesinc/lnxdsp-linux/commit/ddfcfe4efefc0ad769009d41f9ff6b8b206046d5.

Tested by repo init of develop/yocto-2.0.0 branch and `source setup-environment -m adsp-sc589-mini` followed by `bitbake adsp-sc5xx-minimal`