### PR TITLE
Release 3.1.2 hotfix 2

### DIFF
--- a/release-3.1.2.xml
+++ b/release-3.1.2.xml
@@ -11,7 +11,7 @@
   <project remote="oe" revision="4ad41baed6236d499804cbfc4f174042d84fce97" name="meta-openembedded" path="sources/meta-openembedded"/> <!-- kirkstone revision -->
   <project remote="yocto" revision="936c02ec13661bd86a05f7f90e1b920d5092d670" name="meta-arm" path="sources/meta-arm"/> <!-- kirkstone revision -->
 
-  <project remote="adigithub" revision="refs/tags/3.1.2-rel-1" name="lnxdsp-adi-meta" path="sources/meta-adi"/>
+  <project remote="adigithub" revision="refs/tags/3.1.2-rel-2" name="lnxdsp-adi-meta" path="sources/meta-adi"/>
   <project remote="adigithub" revision="refs/tags/3.1.0-rel" name="lnxdsp-scripts" path="sources">
 	  <linkfile dest="setup-environment" src="setup-environment"/>
   </project>>


### PR DESCRIPTION
Updating the lnxdsp-adi-meta layer to use the latest 3.1.2 release tag, which include a fix for the broken openocd Yocto recipe.