### PR TITLE
Pin main.xml to Yocto 5.0.18

### DIFF
--- a/main.xml
+++ b/main.xml
@@ -7,9 +7,10 @@
   <remote fetch="https://github.com/openembedded" name="oe"/>
   <remote fetch="https://github.com/analogdevicesinc" name="adigithub"/>
 
-  <project remote="yocto" revision="ec220ae083dba35c279192b2249ad03fe238446e" name="poky" path="sources/poky"/> <!-- scarthgap revision -->
-  <project remote="oe" revision="b9fb6556a3c8a3e477dce334205b658cb79ad501" name="meta-openembedded" path="sources/meta-openembedded"/> <!-- scarthgap revision -->
-  <project remote="yocto" revision="8e0f8af90fefb03f08cd2228cde7a89902a6b37c" name="meta-arm" path="sources/meta-arm"/> <!-- master revision -->
+  <!-- yocto scarthgap 5.0.18 -->
+  <project remote="yocto" revision="44dcf08572ce391d7c0df4f8c7510af5e096baca" name="poky" path="sources/poky"/>
+  <project remote="oe" revision="ae7dfb12245c7f9b9a353499e2688015bd4e6413" name="meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="yocto" revision="a81c19915b5b9e71ed394032e9a50fd06919e1cd" name="meta-arm" path="sources/meta-arm"/>
 
   <project remote="adigithub" revision="main" name="lnxdsp-adi-meta" path="sources/meta-adi">
   	<linkfile src="tools/setup-environment" dest="setup-environment"/>


### PR DESCRIPTION
With the removal of dev.xml, main.xml is the xml file for the latest changes. Pinning main.xml to the latest supported Yocto release for scarthgap.